### PR TITLE
Use an explicit name for migrations

### DIFF
--- a/squery_pg/migrations.py
+++ b/squery_pg/migrations.py
@@ -29,14 +29,14 @@ VERSION_MULTIPLIER = 10000
 MIGRATION_TABLE = 'migrations'
 GET_VERSION_SQL = sqlize_pg.Select(what='version',
                                    sets=MIGRATION_TABLE,
-                                   where='package = %(package)s')
+                                   where='name = %(name)s')
 SET_VERSION_SQL = sqlize_pg.Replace(table=MIGRATION_TABLE,
-                                    constraints=('package',),
-                                    cols=('package', 'version'))
+                                    constraints=('name',),
+                                    cols=('name', 'version'))
 CREATE_MIGRATION_TABLE_SQL = """
 CREATE TABLE {table:s}
 (
-    package varchar primary key,
+    name varchar primary key,
     version integer null
 );
 """.format(table=MIGRATION_TABLE)
@@ -113,49 +113,49 @@ def unpack_version(version):
     return (major_version, minor_version)
 
 
-def recreate(db, package):
+def recreate(db, name):
     db.recreate()
     db.executescript(CREATE_MIGRATION_TABLE_SQL)
-    db.execute(SET_VERSION_SQL, dict(package=package, version=0))
+    db.execute(SET_VERSION_SQL, dict(name=name, version=0))
     return (0, 0)
 
 
-def get_version(db, package):
+def get_version(db, name):
     """ Query database and return migration version. WARNING: side effecting
     function! if no version information can be found, any existing database
     matching the passed one's name will be deleted and recreated.
 
-    :param db:  connetion object
-    :param package: associated package name
-    :returns:   current migration version
+    :param db:      connetion object
+    :param name:    associated name
+    :returns:       current migration version
     """
     try:
-        result = db.fetchone(GET_VERSION_SQL, dict(package=package))
+        result = db.fetchone(GET_VERSION_SQL, dict(name=name))
     except psycopg2.ProgrammingError as exc:
         if 'does not exist' in str(exc):
-            return recreate(db, package)
+            return recreate(db, name)
         raise
     else:
         if result is None:
-            set_version(db, package, 0, 0)
+            set_version(db, name, 0, 0)
             return (0, 0)
         version = result['version']
         return unpack_version(version)
 
 
-def set_version(db, package, major_version, minor_version):
+def set_version(db, name, major_version, minor_version):
     """ Set database migration version
 
     :param db:             connetion object
-    :param package:        package name
+    :param name:           associated name
     :param major_version:  integer major version of migration
     :param minor_version:  integer minor version of migration
     """
     version = pack_version(major_version, minor_version)
-    db.execute(SET_VERSION_SQL, dict(package=package, version=version))
+    db.execute(SET_VERSION_SQL, dict(name=name, version=version))
 
 
-def run_migration(package, major_version, minor_version, db, mod, conf={}):
+def run_migration(name, major_version, minor_version, db, mod, conf={}):
     """ Run migration script
 
     :param major_version: major version number of the migration
@@ -166,20 +166,20 @@ def run_migration(package, major_version, minor_version, db, mod, conf={}):
     """
     with db.transaction():
         mod.up(db, conf)
-        set_version(db, package, major_version, minor_version)
+        set_version(db, name, major_version, minor_version)
 
 
-def migrate(db, package, conf={}):
+def migrate(db, name, package, conf={}):
     """ Run all migrations that have not been run
 
     Migrations will be run inside a transaction.
 
     :param db:              database connection object
+    :param name:            name associated with the migrations
     :param package:         package that contains the migrations
     :param conf:            application configuration object
     """
-    (current_major_version, current_minor_version) = get_version(db, package)
-    package_name = package
+    (current_major_version, current_minor_version) = get_version(db, name)
     package = importlib.import_module(package)
     logging.debug('Migration version for %s is %s.%s',
                   package.__name__,
@@ -191,5 +191,5 @@ def migrate(db, package, conf={}):
                          current_minor_version + 1)
     for (modname, major_version, minor_version) in migrations:
         mod = load_mod(modname, package)
-        run_migration(package_name, major_version, minor_version, db, mod, conf)
+        run_migration(name, major_version, minor_version, db, mod, conf)
         logging.debug("Finished migrating to %s", modname)


### PR DESCRIPTION
This PR in an update on PR #7 which forces migrations sets to be given a name, instead of using the package name by default. As before, these are tracked per database.
